### PR TITLE
bug fix

### DIFF
--- a/shred.go
+++ b/shred.go
@@ -4,7 +4,10 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"sync"
 )
+
+var wg sync.WaitGroup
 
 // Conf is a object containing all choices of the user
 type Conf struct {
@@ -44,7 +47,9 @@ func (conf Conf) Dir(path string) error {
 		stats, _ := os.Stat(path)
 
 		if stats.IsDir() == false {
+			wg.Add(1)
 			go conf.File(path)
+			wg.Wait()
 		}
 		return nil
 	})
@@ -72,6 +77,7 @@ func (conf Conf) File(path string) error {
 			return err
 		}
 	}
+	wg.Done()
 	return nil
 }
 


### PR DESCRIPTION
Dir and Path wont work since nothing is waiting for goroutine File() to finish
code used:
```go

package main

import (
	"fmt"
	"os"
	"os/user"
	"path/filepath"

	"github.com/r4wm/shred"
)

func main() {
	shredconf := shred.Conf{
		Times:  10,
		Zeros:  false,
		Remove: false,
	}

	usr, err := user.Current()
	if err != nil {
		panic(err)
	}

	fmt.Printf("%#v\n", shredconf)

	delete_path := filepath.Join(usr.HomeDir, "Desktop", "delete_me")
	if _, err := os.Stat(delete_path); os.IsNotExist(err) {
		fmt.Printf("%s does not exist, create the dir, add your files and try again.\n", delete_path)
	}

	fmt.Printf("Shredding everything in %s in %d seconds, Quit now or forever hold your peace..\n", delete_path, 3)

	// time.Sleep(1 * time.Second)

	if err := shredconf.Dir(delete_path); err != nil {
		panic(err)
	}

	fmt.Println("Done")

	fmt.Printf("%#v\n", shredconf)

	// if err = shredconf.File("/home/rmintz/Desktop/delete_me/stuff.txt"); err != nil {
	// 	panic(err)
	// }

	// println("Ran again..")
}
```

result: 
```bash
[@timeshot shred]$ go run ../cmd/main.go
shred.Conf{Times:10, Zeros:false, Remove:false}
Shredding everything in /home/rmintz/Desktop/delete_me in 3 seconds, Quit now or forever hold your peace..
Done
shred.Conf{Times:10, Zeros:false, Remove:false}
[@timeshot shred]$ 
[@timeshot shred]$ 
[@timeshot shred]$ 
[@timeshot shred]$ cat ~/Desktop/delete_me/stuff.txt
haha
[@timeshot shred]$
```
with fix:
```bash
[@timeshot shred]$ 
[@timeshot shred]$ go run ../cmd/main.go
shred.Conf{Times:10, Zeros:false, Remove:false}
Shredding everything in /home/rmintz/Desktop/delete_me in 3 seconds, Quit now or forever hold your peace..
Done
shred.Conf{Times:10, Zeros:false, Remove:false}
[@timeshot shred]$ 
[@timeshot shred]$ 
[@timeshot shred]$ cat ~/Desktop/delete_me/stuff.txt
tQ���[@timeshot shred]$ 
```
